### PR TITLE
npmjs ではなく GitHub への参照に変更します

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,7 @@
   "requires": true,
   "dependencies": {
     "@umm/unirx": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/@umm/unirx/-/unirx-5.5.4.tgz",
-      "integrity": "sha512-TYrBjpQflWchDXrn6BGTi96tRIzdlOfeeTXodDwsSH1aJ4OY7AMRkJ4wJMxtsHi55w+EDxRfP0HN16rCGih0sw==",
+      "version": "github:umm-projects/unirx#8ded122cd432aa0b3c8ea44b53953d308e416406",
       "requires": {
         "glob": "7.1.2",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scripts"
   ],
   "dependencies": {
-    "@umm/unirx": "~5",
+    "@umm/unirx": "github:umm-projects/unirx.git",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
* JS じゃないファイルを npmjs で管理するのは NG かと思い、GitHub を参照するように変更しました。