### PR TITLE
iOS で稀に Texture2D 以外のインスタンスが流れてくるコトがある問題を修正

### DIFF
--- a/Assets/Scripts/UniRx/UnityEngineBridge/ObservableUnityWebRequest.cs
+++ b/Assets/Scripts/UniRx/UnityEngineBridge/ObservableUnityWebRequest.cs
@@ -36,10 +36,17 @@ namespace UniRx {
         }
 
         public static IObservable<Texture2D> GetTexture(string url, Dictionary<string, string> requestHeaderMap = null, IProgress<float> progress = null) {
-            return Request(
-                UnityWebRequestTexture.GetTexture(url),
+            // XXX: 本来は UnityWebRequestTexture.GetTexture() を使うべき
+            //   Unity 2017.1.1p3 時点で「iOS に於いて、大量にリクエストを送ると downloadHandler に設定されるインスタンスが不正に書き換わる」
+            //   という問題があるため、従来のやり方で Texture2D のインスタンスを生成します。
+            return Get(
+                url,
+                (DownloadHandler downloadHandler) => {
+                    Texture2D texture2D = new Texture2D(2, 2, TextureFormat.RGBA32, false, false);
+                    texture2D.LoadImage(downloadHandler.data);
+                    return texture2D;
+                },
                 requestHeaderMap,
-                (DownloadHandlerTexture downloadHandler) => downloadHandler.texture,
                 progress
             );
         }


### PR DESCRIPTION
* `UnityWebRequestTexture.GetTexture()` を連続で用いると、iOS でインスタンスが不正に書き換わる問題があることが判明しました。
* 上記メソッドが修正されるまでの回避策として、通常のリクエスト送信を行い downloadHandler.data を Texture2D に変換するという従来のやり方に戻します。