### PR TITLE
Remove GetMovieTexture() method from Unity 2018.2 higher

### DIFF
--- a/Assets/Scripts/UniRx/UnityEngineBridge/ObservableUnityWebRequest.cs
+++ b/Assets/Scripts/UniRx/UnityEngineBridge/ObservableUnityWebRequest.cs
@@ -58,7 +58,7 @@ namespace UniRx {
             );
         }
 
-#if !UNITY_IOS && !UNITY_ANDROID
+#if !UNITY_IOS && !UNITY_ANDROID && !UNITY_2018_2_OR_NEWER
         public static IObservable<MovieTexture> GetMovieTexture(string url, Dictionary<string, string> requestHeaderMap = null, IProgress<float> progress = null) {
             return Request(
                 UnityWebRequestMultimedia.GetMovieTexture(url),
@@ -306,6 +306,7 @@ namespace UniRx {
             }
         }
 
+        [PublicAPI]
         public class UnityWebRequestErrorException : Exception {
 
             public string RawErrorMessage {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,4 +1,39 @@
 {
-	"dependencies": {
-	}
+  "dependencies": {
+    "com.unity.ads": "2.0.8",
+    "com.unity.analytics": "2.0.16",
+    "com.unity.package-manager-ui": "1.9.11",
+    "com.unity.purchasing": "2.0.3",
+    "com.unity.textmeshpro": "1.2.4",
+    "com.unity.modules.ai": "1.0.0",
+    "com.unity.modules.animation": "1.0.0",
+    "com.unity.modules.assetbundle": "1.0.0",
+    "com.unity.modules.audio": "1.0.0",
+    "com.unity.modules.cloth": "1.0.0",
+    "com.unity.modules.director": "1.0.0",
+    "com.unity.modules.imageconversion": "1.0.0",
+    "com.unity.modules.imgui": "1.0.0",
+    "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.modules.particlesystem": "1.0.0",
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0",
+    "com.unity.modules.screencapture": "1.0.0",
+    "com.unity.modules.terrain": "1.0.0",
+    "com.unity.modules.terrainphysics": "1.0.0",
+    "com.unity.modules.tilemap": "1.0.0",
+    "com.unity.modules.ui": "1.0.0",
+    "com.unity.modules.uielements": "1.0.0",
+    "com.unity.modules.umbra": "1.0.0",
+    "com.unity.modules.unityanalytics": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0",
+    "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+    "com.unity.modules.unitywebrequestaudio": "1.0.0",
+    "com.unity.modules.unitywebrequesttexture": "1.0.0",
+    "com.unity.modules.unitywebrequestwww": "1.0.0",
+    "com.unity.modules.vehicles": "1.0.0",
+    "com.unity.modules.video": "1.0.0",
+    "com.unity.modules.vr": "1.0.0",
+    "com.unity.modules.wind": "1.0.0",
+    "com.unity.modules.xr": "1.0.0"
+  }
 }

--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -3,13 +3,18 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 4
+  serializedVersion: 7
   m_ExternalVersionControlSupport: Hidden Meta Files
   m_SerializationMode: 2
+  m_LineEndingsForNewScripts: 1
   m_DefaultBehaviorMode: 0
   m_SpritePackerMode: 0
   m_SpritePackerPaddingPower: 1
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd
+  m_EtcTextureCompressorBehavior: 0
+  m_EtcTextureFastCompressor: 2
+  m_EtcTextureNormalCompressor: 2
+  m_EtcTextureBestCompressor: 5
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
   m_ProjectGenerationRootNamespace: 
   m_UserGeneratedProjectSuffix: 
   m_CollabEditorSettings:


### PR DESCRIPTION
## What

* Fixes #23 